### PR TITLE
fix: 修复子应用媒体元素资源路径错误的问题

### DIFF
--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -77,6 +77,8 @@ declare global {
     HTMLLinkElement: typeof HTMLLinkElement;
     // script type
     HTMLScriptElement: typeof HTMLScriptElement;
+    // media type
+    HTMLMediaElement: typeof HTMLMediaElement;
     EventTarget: typeof EventTarget;
     Event: typeof Event;
     ShadowRoot: typeof ShadowRoot;
@@ -576,6 +578,7 @@ function patchRelativeUrlEffect(iframeWindow: Window): void {
   fixElementCtrSrcOrHref(iframeWindow, iframeWindow.HTMLSourceElement, "src");
   fixElementCtrSrcOrHref(iframeWindow, iframeWindow.HTMLLinkElement, "href");
   fixElementCtrSrcOrHref(iframeWindow, iframeWindow.HTMLScriptElement, "src");
+  fixElementCtrSrcOrHref(iframeWindow, iframeWindow.HTMLMediaElement, "src");
 }
 
 /**

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -165,7 +165,8 @@ export function fixElementCtrSrcOrHref(
     | typeof HTMLAnchorElement
     | typeof HTMLSourceElement
     | typeof HTMLLinkElement
-    | typeof HTMLScriptElement,
+    | typeof HTMLScriptElement
+    | typeof HTMLMediaElement,
   attr
 ): void {
   // patch setAttribute


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [ x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x ] `npm run test`通过

##### 详细描述

- 特性
- 关联issue
